### PR TITLE
Fix issue #99

### DIFF
--- a/src/app/core/transport.service.ts
+++ b/src/app/core/transport.service.ts
@@ -28,7 +28,7 @@ interface transportProvider {
 }
 
 class OpendataCHProvider implements transportProvider {
-  private url = 'http://transport.opendata.ch/v1/';
+  private url = 'https://transport.opendata.ch/v1/';
 
   constructor(private http: Http) {
   }


### PR DESCRIPTION
Switch the transport api url protocol from 'http' to 'https' to avoid
the browser to block the requests as they are sended by a
HTTPS-served app.

Fix: #99